### PR TITLE
Update for Laravel Mix v6 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "node-cmd": "^3.0.0"
   },
   "peerDependencies": {
-    "laravel-mix": "^4.0||^5.0"
+    "laravel-mix": "^4.0||^5.0||^6.0"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
This PR updates the peer dependency to include laravel-mix@^6.0. It is still compatible with mix 4 and 5.